### PR TITLE
Fix trackball scroll direction by swapping XY axes

### DIFF
--- a/boards/shields/tessera/tessera_right.overlay
+++ b/boards/shields/tessera/tessera_right.overlay
@@ -46,7 +46,7 @@
     trackball_listener: trackball_listener {
         compatible = "zmk,input-listener";
         device = <&trackball>;
-        input-processors = <&zip_xy_transform (INPUT_TRANSFORM_X_INVERT | INPUT_TRANSFORM_Y_INVERT)>;
+        input-processors = <&zip_xy_transform (INPUT_TRANSFORM_XY_SWAP | INPUT_TRANSFORM_Y_INVERT)>;
     };
 };
 


### PR DESCRIPTION
Corrected the trackball input transformation to properly map scroll directions. Changed from inverting both X and Y axes to swapping XY axes and inverting Y axis. This ensures that scrolling up/down and left/right work in the correct directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)