### PR TITLE
Pin ZMK to v0.3.0 to fix build failure with Zephyr 4.1

### DIFF
--- a/config/west.yml
+++ b/config/west.yml
@@ -7,7 +7,7 @@ manifest:
   projects:
     - name: zmk
       remote: zmkfirmware
-      revision: main
+      revision: edf5c08
       import: app/west.yml
     - name: zmk-driver-paw3222
       remote: sekigon-gonnoc


### PR DESCRIPTION
## Summary
- Pin ZMK to commit edf5c08 (v0.3.0) to fix build failures caused by Zephyr 4.1 upgrade

## Problem
ZMK main branch was upgraded to Zephyr 4.1, which requires all board definitions to use Hardware Model v2 (HWMv2). Our custom board (akdk_bt1) still uses the old directory structure (`boards/arm/akdk_bt1/`), causing build failures:

```
CMake Error at /tmp/zmk-config/zephyr/cmake/modules/kconfig.cmake:396 (message):
'/tmp/tmp.kTU6NpKyj8/Kconfig/soc/Kconfig.defconfig' not found
```

## Solution
Pinned ZMK to commit edf5c08 (v0.3.0, released August 1, 2024), which uses Zephyr 3.5 and doesn't require HWMv2 migration.

## Future Work
This is a temporary solution. Long-term options:
1. Migrate akdk_bt1 board definition to HWMv2 format (`boards/nordic/akdk_bt1/`)
2. Continue using pinned version and periodically update to newer stable releases

## References
- [ZMK Zephyr 4.1 Update Blog Post](https://zmk.dev/blog/2025/12/09/zephyr-4-1)
- [Hardware Model v2 Migration Guide](https://docs.zephyrproject.org/latest/releases/migration-guide-3.7.html)
- [ZMK v0.3.0 Release](https://github.com/zmkfirmware/zmk/releases/tag/v0.3.0)

## Test Plan
- [x] Update config/west.yml to pin ZMK revision
- [ ] Verify build succeeds in GitHub Actions
- [ ] Test firmware on actual hardware